### PR TITLE
Fixed 2 bugs: popcount for first individual is now 1; Off-by-1 bug wh…

### DIFF
--- a/phylip2structure.pl
+++ b/phylip2structure.pl
@@ -63,7 +63,7 @@ my %enum;
 my %popcodes;
 if ($popmap){
     open ( POPMAP, $popmap) || die "Derp: Can't open $popmap: $!";
-    my $popcount = 0;
+    my $popcount = 1;
     while (<POPMAP>){
         chomp;
         my @c = split /\s+/, $_;
@@ -181,7 +181,7 @@ while ( my $line = <PHY> ){
 
 close PHY;
 close OUTFILE;
-print ("Done! Outputted ", $samplecount, " samples and ", $snpcount, " SNPs.\n");
+print ("Done! Outputted ", $samplecount, " samples and ", $snpcount+1, " SNPs.\n");
 exit;
 
 ############################SUBROUTINES######################################


### PR DESCRIPTION
…en printing snpcount to STDOUT

Bug 1: In the output structure file, the first individual would be 0 when it was supposed to be 1. If >1 individual was included in pop1, the bug would be: 
```
ind1\t0 # pop1
ind1\t0 # pop1
ind2\t1 # still pop1
ind2\t1 # still pop1
```
Bug 2: Fixed an off-by-1 bug when printing $snpcount to stdout